### PR TITLE
Retrieve package version information via `Node` script rather than `bash` to address #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "bin": {
-    "get-release-type": "./scripts/get-release-type.js"
+    "get-release-type": "./scripts/get-release-type.js",
+    "get-version": "./scripts/get-version.js"
   },
   "scripts": {
     "build": "echo",

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const util = require('util')
+const exec = util.promisify(require('child_process').exec)
+
+const whichPackage = process.argv[2]
+const whichVersion = process.argv[3]
+
+/**
+ * Get either the current or previous version of an NPM package
+ *
+ * @param {String} whichPackage NPM package to interrogate
+ * @param {?String} whichVersion If 'previous' then previous version, otherwise current
+ *
+ * @returns {String|undefined} Current or previous version of the NPM package
+ */
+async function getVersion(whichPackage, whichVersion) {
+    const {stdout, stderr} = await exec(`npm show ${whichPackage} versions --json`)
+
+    if (!stderr) {
+        const offset = (whichVersion === 'previous') ? 1 : 0
+        const versions = JSON.parse(stdout)
+
+        console.log(versions[versions.length - 1 - offset])
+    }
+}
+
+getVersion(whichPackage, whichVersion)

--- a/scripts/package-info.sh
+++ b/scripts/package-info.sh
@@ -77,11 +77,7 @@ function get_changelog_url() {
 # Get current package version
 #
 function get_current_version() {
-    local package=$1
-
-    get_versions "$package"
-
-    echo "${versions[${#versions[@]}-1]}"
+    get-version "$1"
 }
 
 #
@@ -159,11 +155,7 @@ function get_package_name () {
 # Get previous package version
 #
 function get_previous_version() {
-    local package=$1
-
-    get_versions "$package"
-
-    echo "${versions[${#versions[@]}-2]}"
+    get-version "$1" previous
 }
 
 #
@@ -174,31 +166,4 @@ function get_release_type() {
     local new_version=$2
 
     get-release-type "$previous_version" "$current_version"
-}
-
-#
-# Get all published versions of package in NPM
-#
-function get_versions() {
-    # If "versions" is already populated don't need to populate it again
-    if [ -z ${versions+x} ];
-    then
-        local package=$1
-        local version_info_string
-        local version_info_string_array
-
-        version_info_string=$(npm view "$package" versions)
-        version_info_string_array=( $(echo "$version_info_string" | tr ' ' '\n') )
-
-        for ((i=0; i < ${#version_info_string_array[@]}; i++))
-        do
-            # if not first or last element, which are "[" and "]" (without quotes), respectively
-            if [ $i -ne 0 ] && [ $i -ne $((${#version_info_string_array[@]}-1)) ];
-            then
-                # is a global variable
-                # strips off apostrophes and commas
-                versions[$((i-1))]="${version_info_string_array[$i]//[\',]}"
-            fi
-        done
-    fi
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes ciena-blueplanet/ciena-devops#11

# CHANGELOG
* Resolved [#11](https://github.com/ciena-blueplanet/ciena-devops/issues/11) - Current approach to retrieving NPM package version information is not practical