### PR TITLE
Fix bug related to npm registry not always being timely

### DIFF
--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -6,25 +6,41 @@ const util = require('util')
 const exec = util.promisify(require('child_process').exec)
 
 const whichPackage = process.argv[2]
-const whichVersion = process.argv[3]
+const packageVersion = process.argv[3]
+const whichVersion = process.argv[4]
 
 /**
  * Get either the current or previous version of an NPM package
  *
  * @param {String} whichPackage NPM package to interrogate
+ * @param {String} packageVersion "version" property value from package.json file
  * @param {?String} whichVersion If 'previous' then previous version, otherwise current
  *
  * @returns {String|undefined} Current or previous version of the NPM package
  */
-async function getVersion(whichPackage, whichVersion) {
+async function getVersion(whichPackage, packageVersion, whichVersion) {
     const {stdout, stderr} = await exec(`npm show ${whichPackage} versions --json`)
 
     if (!stderr) {
-        const offset = (whichVersion === 'previous') ? 1 : 0
         const versions = JSON.parse(stdout)
+        const publishedNpmVersion = versions[versions.length-1]
 
-        console.log(versions[versions.length - 1 - offset])
+        let latest
+        let previous
+
+        // NPM registry has latest package version
+        if (publishedNpmVersion == packageVersion) {
+            latest = publishedNpmVersion
+            previous = versions[versions.length-2]
+
+        // NPM registry does not have latest package version
+        } else {
+            latest = packageVersion
+            previous = versions[versions.length-1]
+        }
+
+        console.log(whichVersion === 'previous' ? previous : latest)
     }
 }
 
-getVersion(whichPackage, whichVersion)
+getVersion(whichPackage, packageVersion, whichVersion)

--- a/scripts/package-info.sh
+++ b/scripts/package-info.sh
@@ -77,7 +77,9 @@ function get_changelog_url() {
 # Get current package version
 #
 function get_current_version() {
-    get-version "$1"
+    version=$(get_package_version)
+
+    get-version "$1" "$version"
 }
 
 #
@@ -152,10 +154,19 @@ function get_package_name () {
 }
 
 #
+# Get "version" property from package.json file
+#
+function get_package_version () {
+    echo "$(node -e "console.log(require('./package.json').version)")"
+}
+
+#
 # Get previous package version
 #
 function get_previous_version() {
-    get-version "$1" previous
+    version=$(get_package_version)
+
+    get-version "$1" "$version" previous
 }
 
 #


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
Yes

## Summary
Fix bug related to npm registry not always being timely

* https://github.com/ciena-blueplanet/ciena-devops-testbed/pull/38 release 3.2.0 was using this PR so this proves that nothing was broken by these changes.
* The attached screenshot captures the exercising of the logic of these changes
* Seeing it come together in a real-world npm timing issue will have to play itself out over time

## Issue Number(s)
* Closes #10 

## Screenshots or recordings
![screen shot 2018-03-12 at 12 15 19 pm](https://user-images.githubusercontent.com/435544/37298959-eaa2b770-25ef-11e8-8b79-62ad986ae140.png)


## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] I have evaluated if the _README.md_ documentation needs to be updated
* [x] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [x] I have evaluated if DocBlock headers needed to be added or updated
* [x] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG

* Closes [#10](https://github.com/ciena-blueplanet/ciena-devops/issues/10) - Fix bug related to npm registry not always being timely